### PR TITLE
reconfigure ymls

### DIFF
--- a/.github/workflows/run_update_raster_stats.yml
+++ b/.github/workflows/run_update_raster_stats.yml
@@ -1,9 +1,10 @@
-name: Update exposure rasters
+name: Update exposure raster stats
 
 on:
+  repository_dispatch:
+    types:
+      - trigger_exposure_raster_stats
   workflow_dispatch:
-  schedule:
-      - cron: "5 23 * * *" # 23:05 UTC, 5 minutes after ds-floodscan-ingest runs
 
 jobs:
   run-script:
@@ -30,17 +31,9 @@ jobs:
     - name: Run script
       env:
         DEV_BLOB_SAS: ${{ secrets.DEV_BLOB_SAS }}
+        AZURE_DB_PW_DEV: ${{ secrets.AZURE_DB_PW_DEV }}
+        AZURE_DB_PW_PROD: ${{ secrets.AZURE_DB_PW_PROD }}
+        AZURE_DB_UID: ${{ secrets.AZURE_DB_UID_DEV }}
 
       run: |
-        python pipelines/update_exposure.py
-
-    - name: Trigger raster stats pipeline
-      uses: actions/github-script@v5
-      with:
-        github-token: ${{ secrets.PAT }}
-        script: |
-          await github.repos.createDispatchEvent({
-              owner: 'OCHA-DAP',
-              repo: 'ds-floodexposure-monitoring',
-              event_type: 'trigger_exposure_raster_stats'
-          })
+        python pipelines/update_raster_stats.py


### PR DESCRIPTION
Adding the raster stats yml `run_update_raster_stats.yml` to `main` so we can test it using `workflow_dispatch` once `database-outputs` has been merged into `exposure-pipeline`. 

Also adding the `respository_dispatch` trigger step to `run_update_exposure.yml`, so that triggering can be tested. And removing the steps that previously triggered the app to reload its data, since we don't do this anymore.

This PR should be merged at the same time as `database-outputs` is merged into `exposure-pipeline`. It can be merged before, but it will just cause the `run_update_raster_stats.yml` action to fail, since the `update_raster_stats.py` file will not yet exist on the `exposure-pipeline` branch.