### PR TITLE
Add regions

### DIFF
--- a/.github/workflows/run_update_raster_stats.yml
+++ b/.github/workflows/run_update_raster_stats.yml
@@ -35,3 +35,4 @@ jobs:
 
       run: |
         python pipelines/update_raster_stats.py
+        python pipelines/update_raster_stats_regions.py

--- a/exploration/regions.md
+++ b/exploration/regions.md
@@ -27,6 +27,16 @@ from src.constants import *
 ```
 
 ```python
+engine = database.get_engine()
+```
+
+```python
+database.create_flood_exposure_region_table(
+    "floodscan_exposure_regions", database.get_engine()
+)
+```
+
+```python
 for region in REGIONS:
     print(region)
 ```
@@ -37,4 +47,8 @@ SELECT *
 FROM app.floodscan_exposure
 WHERE iso=:pcode AND adm_level=:adm_level
 """
+```
+
+```python
+query
 ```

--- a/exploration/regions.md
+++ b/exploration/regions.md
@@ -1,0 +1,40 @@
+---
+jupyter:
+  jupytext:
+    formats: ipynb,md
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.16.1
+  kernelspec:
+    display_name: ds-floodexposure-monitoring
+    language: python
+    name: ds-floodexposure-monitoring
+---
+
+# Regions
+
+```python
+%load_ext jupyter_black
+%load_ext autoreload
+%autoreload 2
+```
+
+```python
+from src.utils import database
+from src.constants import *
+```
+
+```python
+for region in REGIONS:
+    print(region)
+```
+
+```python
+query = """
+SELECT *
+FROM app.floodscan_exposure
+WHERE iso=:pcode AND adm_level=:adm_level
+"""
+```

--- a/pipelines/update_raster_stats_regions.py
+++ b/pipelines/update_raster_stats_regions.py
@@ -1,0 +1,37 @@
+from typing import List
+
+import pandas as pd
+
+from src.constants import REGIONS
+from src.utils import database
+
+
+def get_existing_adm_stats(pcodes: List[str], engine) -> pd.DataFrame:
+    query = f"""
+    SELECT *
+    FROM app.floodscan_exposure
+    WHERE pcode IN ({", ".join([f"'{pcode}'" for pcode in pcodes])})
+    """
+    return pd.read_sql(query, con=engine)
+
+
+if __name__ == "__main__":
+    engine = database.get_engine(stage="dev")
+
+    for region in REGIONS:
+        print(f"Processing {region['iso3']} region {region['region_number']}")
+        adm_stats_df = get_existing_adm_stats(region["pcodes"], engine)
+        region_stats_df = (
+            adm_stats_df.groupby("valid_date")["sum"].sum().reset_index()
+        )
+        region_stats_df["iso3"] = region["iso3"].upper()
+        region_stats_df["region_number"] = region["region_number"]
+        region_stats_df.to_sql(
+            "floodscan_exposure_regions",
+            schema="app",
+            con=engine,
+            if_exists="append",
+            chunksize=10000,
+            index=False,
+            method=database.postgres_upsert,
+        )

--- a/src/constants.py
+++ b/src/constants.py
@@ -13,18 +13,21 @@ REGIONS = [
     {
         "adm_level": 1,
         "iso3": "cod",
+        "region_number": 1,
         "region_name": "Zone 1",
         "pcodes": [BASUELE1, HAUTUELE1, TSHOPO1],
     },
     {
         "adm_level": 1,
         "iso3": "cod",
+        "region_number": 2,
         "region_name": "Zone 2",
         "pcodes": [NORDKIVU1, SUDKIVU1],
     },
     {
         "adm_level": 1,
         "iso3": "cod",
+        "region_number": 3,
         "region_name": "Zone 3",
         "pcodes": [TANGANYIKA1],
     },

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,2 +1,31 @@
 ISO3S = ["ner", "nga", "cmr", "tcd", "bfa", "eth", "som", "ssd", "mli", "cod"]
 CHD_GREEN = "#1bb580"
+
+# specific pcodes for building regions
+NORDKIVU1 = "CD61"
+SUDKIVU1 = "CD62"
+TANGANYIKA1 = "CD74"
+BASUELE1 = "CD52"
+HAUTUELE1 = "CD53"
+TSHOPO1 = "CD51"
+
+REGIONS = [
+    {
+        "adm_level": 1,
+        "iso3": "cod",
+        "region_name": "Zone 1",
+        "pcodes": [BASUELE1, HAUTUELE1, TSHOPO1],
+    },
+    {
+        "adm_level": 1,
+        "iso3": "cod",
+        "region_name": "Zone 2",
+        "pcodes": [NORDKIVU1, SUDKIVU1],
+    },
+    {
+        "adm_level": 1,
+        "iso3": "cod",
+        "region_name": "Zone 3",
+        "pcodes": [TANGANYIKA1],
+    },
+]

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -37,6 +37,31 @@ def get_engine(stage: Literal["dev", "prod"] = "dev"):
     return create_engine(url)
 
 
+def create_flood_exposure_region_table(dataset, engine):
+    metadata = MetaData()
+    columns = [
+        Column("iso3", CHAR(3)),
+        Column("region_number", Integer),
+        Column("valid_date", Date),
+        Column("sum", REAL),
+    ]
+
+    unique_constraint_columns = ["iso3", "region_number", "valid_date"]
+
+    Table(
+        f"{dataset}",
+        metadata,
+        *columns,
+        UniqueConstraint(
+            *unique_constraint_columns,
+            name=f"{dataset}_unique",
+            postgresql_nulls_not_distinct=True,
+        ),
+        schema="app",
+    )
+    metadata.create_all(engine)
+
+
 def create_flood_exposure_table(dataset, engine):
     """
     Create a table for storing flood exposure data in the database.


### PR DESCRIPTION
Adding regions (i.e. combinations of admins) for raster stats calculations. 

Goes with app PR https://github.com/OCHA-DAP/ds-floodexposure-monitoring-app/pull/35

Basically just runs another pipeline `pipelines/update_raster_stats_regions.py` after the existing raster stats pipeline to aggregate admin-based raster stats into a new DB table `app.floodscan_exposure_regions`. I set it up this way to keep the admin raster stats table clean (i.e., only for actual admin bounds). The definition of the regions is `REGIONS` in `src/constants.py`. The regions are also defined this way in the app repo. This list of dicts can effectively be replaced by whatever way we want to define regions in the future.

Note that because the regional aggregation is quite simple, it's quick to run, so it re-runs on the whole historical record of admin-based raster stats each time. So, adding new regions is nice and simple, just add to the `REGIONS` constant and it'll fill in the historical record.

As discussed, in the long run we'll need a better way to storage and manage regions. Could be a job for a relational DB table for grouping of admins (i.e. one-to-many region-to-admins). But I figured this wasn't worth setting up for what will (hopefully?) be a one-off.