### PR TITLE
Compute terciles

### DIFF
--- a/.github/workflows/run_update_terciles.yml
+++ b/.github/workflows/run_update_terciles.yml
@@ -1,9 +1,9 @@
-name: Update exposure raster stats
+name: Update terciles
 
 on:
   repository_dispatch:
     types:
-      - trigger_exposure_raster_stats
+      - trigger_compute_terciles
   workflow_dispatch:
 
 jobs:
@@ -34,17 +34,4 @@ jobs:
         AZURE_DB_UID: ${{ secrets.AZURE_DB_UID_DEV }}
 
       run: |
-        python pipelines/update_raster_stats.py
-        python pipelines/update_raster_stats_regions.py
-
-    - name: Trigger tercile calculations
-      env:
-        GITHUB_TOKEN: ${{ secrets.PAT }}
-      run: |
-        curl -L \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer $GITHUB_TOKEN" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/OCHA-DAP/ds-floodexposure-monitoring/dispatches \
-          -d '{"event_type":"trigger_compute_terciles"}'
+        python pipelines/update_exposure_tercile.py

--- a/pipelines/update_exposure_tercile.py
+++ b/pipelines/update_exposure_tercile.py
@@ -65,7 +65,7 @@ def assign_tercile(row, boundaries):
 
 
 if __name__ == "__main__":
-    target_date = datetime.today() - timedelta(days=3)
+    target_date = datetime.today() - timedelta(days=1)
     engine = database.get_engine()
 
     print(f"Computing terciles as of {target_date.strftime('%Y-%m-%d')}")

--- a/pipelines/update_exposure_tercile.py
+++ b/pipelines/update_exposure_tercile.py
@@ -128,6 +128,6 @@ if __name__ == "__main__":
         sys.exit(1)
 
     save_df(df_standard, target_date, engine, "current_tercile")
-    save_df(df_region, target_date, engine, "current_tercile_region")
+    save_df(df_region, target_date, engine, "current_tercile_regions")
 
     print("Done!")

--- a/pipelines/update_exposure_tercile.py
+++ b/pipelines/update_exposure_tercile.py
@@ -1,0 +1,121 @@
+import sys
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+from sqlalchemy import text
+
+from src.utils import database
+
+ROLL_WINDOW = 7
+
+ROLLING_QUERY = text(
+    f"""
+    WITH target_dates AS (
+        SELECT
+            pcode,
+            adm_level,
+            valid_date,
+            sum as original_sum
+        FROM app.floodscan_exposure
+        WHERE EXTRACT(MONTH FROM valid_date) = :month
+            AND EXTRACT(DAY FROM valid_date) = :day
+    ),
+    date_ranges AS (
+        SELECT
+            t.pcode,
+            t.adm_level,
+            t.valid_date as target_date,
+            t.original_sum as sum,
+            d.valid_date,
+            d.sum as daily_sum
+        FROM target_dates t
+        JOIN app.floodscan_exposure d
+            ON d.pcode = t.pcode
+            AND d.valid_date BETWEEN t.valid_date - INTERVAL '{ROLL_WINDOW-1} days' AND t.valid_date  # noqa
+    )
+    SELECT
+        pcode,
+        adm_level,
+        target_date as valid_date,
+        AVG(daily_sum) as rolling_avg,
+        sum
+    FROM date_ranges
+    GROUP BY pcode, adm_level, target_date, sum
+    ORDER BY pcode, target_date;
+    """
+)
+
+
+def assign_tercile(row, boundaries):
+    """
+    Assign tercile values based on boundaries.
+    Returns:
+        -1: Below lower tercile
+        0: Between terciles
+        1: Above upper tercile
+    """
+    pcode_bounds = boundaries.loc[row["pcode"]]
+    value = row["sum"]
+    if value < pcode_bounds["lower_tercile"]:
+        return -1
+    elif value <= pcode_bounds["upper_tercile"]:
+        return 0
+    else:
+        return 1
+
+
+if __name__ == "__main__":
+    target_date = datetime.today() - timedelta(days=3)
+    engine = database.get_engine()
+
+    print(f"Computing terciles as of {target_date.strftime('%Y-%m-%d')}")
+    print(f"Using {ROLL_WINDOW}-day rolling average")
+
+    # Get data and calculate rolling averages
+    try:
+        with engine.connect() as con:
+            print("Calculating rolling averages and getting data from db...")
+            df_all = pd.read_sql_query(
+                ROLLING_QUERY,
+                con,
+                params={"month": target_date.month, "day": target_date.day},
+            )
+    except Exception as e:
+        print(f"Error querying database: {e}")
+        sys.exit(1)
+
+    if df_all.empty:
+        print(
+            f"No data retrieved from database for {target_date.strftime('%Y-%m-%d')}"  # noqa
+        )
+        sys.exit(0)
+
+    print("Computing terciles...")
+    tercile_boundaries = df_all.groupby("pcode")["rolling_avg"].agg(
+        lower_tercile=lambda x: np.percentile(x, 33.33),
+        upper_tercile=lambda x: np.percentile(x, 66.67),
+    )
+
+    df_all["tercile"] = df_all.apply(
+        lambda row: assign_tercile(row, tercile_boundaries), axis=1
+    )
+
+    # Filter for target date
+    df_all["valid_date"] = pd.to_datetime(df_all["valid_date"])
+    df_sel = df_all[df_all.valid_date == target_date.strftime("%Y-%m-%d")]
+
+    if len(df_sel) == 0:
+        print(f"No data available for {target_date.strftime('%Y-%m-%d')}")
+        sys.exit(0)
+
+    print("Writing to database...")
+    df_sel.to_sql(
+        "current_tercile",
+        schema="app",
+        con=engine,
+        if_exists="replace",
+        chunksize=10000,
+        index=False,
+    )
+    print("Done!")

--- a/pipelines/update_exposure_tercile.py
+++ b/pipelines/update_exposure_tercile.py
@@ -9,44 +9,82 @@ from src.utils import database
 
 ROLL_WINDOW = 7
 
-ROLLING_QUERY = text(
-    f"""
-    WITH target_dates AS (
+
+def rolling_query(regions=False):
+
+    rolling_query_regions = text(
+        f"""
+        WITH target_dates AS (
+            SELECT
+                region_number,
+                valid_date,
+                sum as original_sum
+            FROM app.floodscan_exposure_regions
+            WHERE EXTRACT(MONTH FROM valid_date) = :month
+                AND EXTRACT(DAY FROM valid_date) = :day
+        ),
+        date_ranges AS (
+            SELECT
+                t.region_number,
+                t.valid_date as target_date,
+                t.original_sum as sum,
+                d.valid_date,
+                d.sum as daily_sum
+            FROM target_dates t
+            JOIN app.floodscan_exposure_regions d
+                ON d.region_number = t.region_number
+                AND d.valid_date BETWEEN t.valid_date - INTERVAL '{ROLL_WINDOW-1} days' AND t.valid_date
+        )
+        SELECT
+            region_number,
+            target_date as valid_date,
+            AVG(daily_sum) as rolling_avg
+        FROM date_ranges
+        GROUP BY region_number, target_date
+        ORDER BY region_number, target_date;
+    """
+    )
+
+    rolling_query_standard = text(
+        f"""
+        WITH target_dates AS (
+            SELECT
+                pcode,
+                adm_level,
+                valid_date,
+                sum as original_sum
+            FROM app.floodscan_exposure
+            WHERE EXTRACT(MONTH FROM valid_date) = :month
+                AND EXTRACT(DAY FROM valid_date) = :day
+        ),
+        date_ranges AS (
+            SELECT
+                t.pcode,
+                t.adm_level,
+                t.valid_date as target_date,
+                t.original_sum as sum,
+                d.valid_date,
+                d.sum as daily_sum
+            FROM target_dates t
+            JOIN app.floodscan_exposure d
+                ON d.pcode = t.pcode
+                AND d.valid_date BETWEEN t.valid_date - INTERVAL '{ROLL_WINDOW-1} days' AND t.valid_date
+        )
         SELECT
             pcode,
             adm_level,
-            valid_date,
-            sum as original_sum
-        FROM app.floodscan_exposure
-        WHERE EXTRACT(MONTH FROM valid_date) = :month
-            AND EXTRACT(DAY FROM valid_date) = :day
-    ),
-    date_ranges AS (
-        SELECT
-            t.pcode,
-            t.adm_level,
-            t.valid_date as target_date,
-            t.original_sum as sum,
-            d.valid_date,
-            d.sum as daily_sum
-        FROM target_dates t
-        JOIN app.floodscan_exposure d
-            ON d.pcode = t.pcode
-            AND d.valid_date BETWEEN t.valid_date - INTERVAL '{ROLL_WINDOW-1} days' AND t.valid_date
+            target_date as valid_date,
+            AVG(daily_sum) as rolling_avg
+        FROM date_ranges
+        GROUP BY pcode, adm_level, target_date
+        ORDER BY pcode, target_date;
+        """
     )
-    SELECT
-        pcode,
-        adm_level,
-        target_date as valid_date,
-        AVG(daily_sum) as rolling_avg
-    FROM date_ranges
-    GROUP BY pcode, adm_level, target_date
-    ORDER BY pcode, target_date;
-    """
-)
+
+    return rolling_query_regions if regions else rolling_query_standard
 
 
-def assign_tercile(row, boundaries):
+def assign_tercile(row, boundaries, id_col):
     """
     Assign tercile values based on boundaries.
     Returns:
@@ -54,7 +92,7 @@ def assign_tercile(row, boundaries):
         0: Between terciles
         1: Above upper tercile
     """
-    pcode_bounds = boundaries.loc[row["pcode"]]
+    pcode_bounds = boundaries.loc[row[id_col]]
     value = row["rolling_avg"]
     if value < pcode_bounds["lower_tercile"]:
         return -1
@@ -64,8 +102,44 @@ def assign_tercile(row, boundaries):
         return 1
 
 
+def save_df(df, id_col, sel_date, engine, output_table):
+
+    if df.empty:
+        print(
+            f"No data retrieved from database for {target_date.strftime('%Y-%m-%d')}"  # noqa
+        )
+        sys.exit(0)
+
+    print("Computing terciles...")
+    tercile_boundaries = df.groupby(id_col)["rolling_avg"].agg(
+        lower_tercile=lambda x: np.percentile(x, 33.33),
+        upper_tercile=lambda x: np.percentile(x, 66.67),
+    )
+
+    df["tercile"] = df.apply(
+        lambda row: assign_tercile(row, tercile_boundaries, id_col), axis=1
+    )
+
+    df["valid_date"] = pd.to_datetime(df["valid_date"])
+    df_sel = df[df.valid_date == sel_date.strftime("%Y-%m-%d")]
+
+    if len(df_sel) == 0:
+        print(f"No data available for {sel_date.strftime('%Y-%m-%d')}")
+        sys.exit(0)
+
+    print("Writing to database...")
+    df_sel.to_sql(
+        output_table,
+        schema="app",
+        con=engine,
+        if_exists="replace",
+        chunksize=10000,
+        index=False,
+    )
+
+
 if __name__ == "__main__":
-    target_date = datetime.today() - timedelta(days=1)
+    target_date = datetime.today() - timedelta(days=2)
     engine = database.get_engine()
 
     print(f"Computing terciles as of {target_date.strftime('%Y-%m-%d')}")
@@ -75,8 +149,13 @@ if __name__ == "__main__":
     try:
         with engine.connect() as con:
             print("Calculating rolling averages and getting data from db...")
-            df_all = pd.read_sql_query(
-                ROLLING_QUERY,
+            df_standard = pd.read_sql_query(
+                rolling_query(regions=False),
+                con,
+                params={"month": target_date.month, "day": target_date.day},
+            )
+            df_region = pd.read_sql_query(
+                rolling_query(regions=True),
                 con,
                 params={"month": target_date.month, "day": target_date.day},
             )
@@ -84,37 +163,13 @@ if __name__ == "__main__":
         print(f"Error querying database: {e}")
         sys.exit(1)
 
-    if df_all.empty:
-        print(
-            f"No data retrieved from database for {target_date.strftime('%Y-%m-%d')}"  # noqa
-        )
-        sys.exit(0)
-
-    print("Computing terciles...")
-    tercile_boundaries = df_all.groupby("pcode")["rolling_avg"].agg(
-        lower_tercile=lambda x: np.percentile(x, 33.33),
-        upper_tercile=lambda x: np.percentile(x, 66.67),
+    save_df(df_standard, "pcode", target_date, engine, "current_tercile")
+    save_df(
+        df_region,
+        "region_number",
+        target_date,
+        engine,
+        "current_tercile_region",
     )
 
-    df_all["tercile"] = df_all.apply(
-        lambda row: assign_tercile(row, tercile_boundaries), axis=1
-    )
-
-    # Filter for target date
-    df_all["valid_date"] = pd.to_datetime(df_all["valid_date"])
-    df_sel = df_all[df_all.valid_date == target_date.strftime("%Y-%m-%d")]
-
-    if len(df_sel) == 0:
-        print(f"No data available for {target_date.strftime('%Y-%m-%d')}")
-        sys.exit(0)
-
-    print("Writing to database...")
-    df_sel.to_sql(
-        "current_tercile",
-        schema="app",
-        con=engine,
-        if_exists="replace",
-        chunksize=10000,
-        index=False,
-    )
     print("Done!")

--- a/pipelines/update_exposure_tercile.py
+++ b/pipelines/update_exposure_tercile.py
@@ -103,7 +103,7 @@ def save_df(df, sel_date, engine, output_table, id_col="pcode"):
 
 
 if __name__ == "__main__":
-    target_date = datetime.today() - timedelta(days=2)
+    target_date = datetime.today() - timedelta(days=1)
     engine = database.get_engine()
 
     print(f"Computing terciles as of {target_date.strftime('%Y-%m-%d')}")

--- a/pipelines/update_exposure_tercile.py
+++ b/pipelines/update_exposure_tercile.py
@@ -32,16 +32,15 @@ ROLLING_QUERY = text(
         FROM target_dates t
         JOIN app.floodscan_exposure d
             ON d.pcode = t.pcode
-            AND d.valid_date BETWEEN t.valid_date - INTERVAL '{ROLL_WINDOW-1} days' AND t.valid_date  # noqa
+            AND d.valid_date BETWEEN t.valid_date - INTERVAL '{ROLL_WINDOW-1} days' AND t.valid_date
     )
     SELECT
         pcode,
         adm_level,
         target_date as valid_date,
-        AVG(daily_sum) as rolling_avg,
-        sum
+        AVG(daily_sum) as rolling_avg
     FROM date_ranges
-    GROUP BY pcode, adm_level, target_date, sum
+    GROUP BY pcode, adm_level, target_date
     ORDER BY pcode, target_date;
     """
 )
@@ -56,7 +55,7 @@ def assign_tercile(row, boundaries):
         1: Above upper tercile
     """
     pcode_bounds = boundaries.loc[row["pcode"]]
-    value = row["sum"]
+    value = row["rolling_avg"]
     if value < pcode_bounds["lower_tercile"]:
         return -1
     elif value <= pcode_bounds["upper_tercile"]:

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -1,6 +1,7 @@
 import os
 from typing import Literal
 
+from dotenv import load_dotenv
 from sqlalchemy import (
     CHAR,
     REAL,
@@ -14,6 +15,8 @@ from sqlalchemy import (
     create_engine,
 )
 from sqlalchemy.dialects.postgresql import insert
+
+load_dotenv()
 
 AZURE_DB_PW_DEV = os.getenv("AZURE_DB_PW_DEV")
 AZURE_DB_PW_PROD = os.getenv("AZURE_DB_PW_PROD")


### PR DESCRIPTION
This PR creates a new `app.current_tercile` table in the database to support display on the map in https://github.com/OCHA-DAP/ds-floodexposure-monitoring-app/pull/36. See screenshot below for an example of what this looks like: 

<img width="609" alt="Screenshot 2024-12-16 at 1 23 17 PM" src="https://github.com/user-attachments/assets/65657ecf-247d-40bc-bea0-a2d0e1a9c3c3" />

I've added a new GHA so this table should be repopulated every day after the raster stats are computed for the previous day. The table will be fully rewritten each time. Really, only the `pcode`, `adm_level`, and `tercile` columns are necessary for the app, but I think having the `valid_date` and `rolling_avg` will be nice to sanity check things if we ever need. 

The terciles are also computed **for each pcode**, not against the distribution for the given date. I've noticed that a lot of pcodes will have 0 as both the lower and upper tercile (which makes sense for areas that aren't often exposed to any flooding). See the note in the code, but in this case an observation of 0 for the current date would be considered average. 

