### PR TITLE
Migrate functions to the new `ocha-stratus` package

### DIFF
--- a/pipelines/update_exposure_quantile.py
+++ b/pipelines/update_exposure_quantile.py
@@ -2,7 +2,7 @@ import sys
 from datetime import datetime, timedelta
 
 import numpy as np
-import ocha_stratus as ocha
+import ocha_stratus as stratus
 import pandas as pd
 from sqlalchemy import text
 
@@ -107,7 +107,7 @@ def save_df(df, sel_date, engine, output_table, id_col="pcode"):
 
 if __name__ == "__main__":
     target_date = datetime.today() - timedelta(days=1)
-    engine = ocha.get_engine(stage=STAGE)
+    engine = stratus.get_engine(stage=STAGE)
 
     print(f"Computing quantiles as of {target_date.strftime('%Y-%m-%d')}")
     print(f"Using {ROLL_WINDOW}-day rolling average")

--- a/pipelines/update_exposure_quantile.py
+++ b/pipelines/update_exposure_quantile.py
@@ -2,11 +2,11 @@ import sys
 from datetime import datetime, timedelta
 
 import numpy as np
+import ocha_stratus as ocha
 import pandas as pd
 from sqlalchemy import text
 
 from src.constants import STAGE
-from src.utils import database
 
 ROLL_WINDOW = 7
 
@@ -107,7 +107,7 @@ def save_df(df, sel_date, engine, output_table, id_col="pcode"):
 
 if __name__ == "__main__":
     target_date = datetime.today() - timedelta(days=1)
-    engine = database.get_engine(stage=STAGE)
+    engine = ocha.get_engine(stage=STAGE)
 
     print(f"Computing quantiles as of {target_date.strftime('%Y-%m-%d')}")
     print(f"Using {ROLL_WINDOW}-day rolling average")

--- a/pipelines/update_raster_stats.py
+++ b/pipelines/update_raster_stats.py
@@ -1,4 +1,4 @@
-import ocha_stratus as ocha
+import ocha_stratus as stratus
 
 from src.constants import ISO3S, REGIONS, STAGE
 from src.datasources import floodscan
@@ -8,7 +8,7 @@ if __name__ == "__main__":
 
     clobber = False
     verbose = False
-    engine = ocha.get_engine(stage=STAGE)
+    engine = stratus.get_engine(stage=STAGE)
     table_name = "floodscan_exposure"
     table_name_regions = "floodscan_exposure_regions"
 

--- a/pipelines/update_raster_stats.py
+++ b/pipelines/update_raster_stats.py
@@ -1,3 +1,5 @@
+import ocha_stratus as ocha
+
 from src.constants import ISO3S, REGIONS, STAGE
 from src.datasources import floodscan
 from src.utils import database
@@ -6,7 +8,7 @@ if __name__ == "__main__":
 
     clobber = False
     verbose = False
-    engine = database.get_engine(stage=STAGE)
+    engine = ocha.get_engine(stage=STAGE)
     table_name = "floodscan_exposure"
     table_name_regions = "floodscan_exposure_regions"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,13 @@ geopandas==1.0.1
 matplotlib==3.9.2
 pandas==2.2.2
 plotly==5.23.0
-pyarrow==17.0.0
-rioxarray==0.17.0
-scipy==1.14.0
+pyarrow
+rioxarray
+scipy
 tqdm==4.66.5
 xarray==2024.7.0
 python-dotenv==1.0.1
 pre-commit==4.0.1
 sqlalchemy==2.0.36
 psycopg2-binary==2.9.10
+ocha-stratus==0.1.1

--- a/src/constants.py
+++ b/src/constants.py
@@ -9,6 +9,16 @@ STAGE = os.getenv("STAGE")
 ISO3S = ["ner", "nga", "cmr", "tcd", "bfa", "eth", "som", "ssd", "mli", "cod"]
 CHD_GREEN = "#1bb580"
 
+PROJECT_PREFIX = "ds-floodexposure-monitoring"
+FLOODSCAN_COG_FILEPATH = "floodscan/daily/v5/processed"
+FIELDMAPS_BASE_URL = "https://data.fieldmaps.io/cod/originals/{iso3}.shp.zip"
+
+WORLDPOP_BASE_URL = (
+    "https://data.worldpop.org/GIS/Population/"
+    "Global_2000_2020_1km_UNadj/2020/{iso3_upper}/"
+    "{iso3}_ppp_2020_1km_Aggregated_UNadj.tif"
+)
+
 # specific pcodes for building regions
 NORDKIVU1 = "CD61"
 SUDKIVU1 = "CD62"

--- a/src/datasources/codab.py
+++ b/src/datasources/codab.py
@@ -1,34 +1,35 @@
+import ocha_stratus as ocha
 import requests
 
-from src.constants import STAGE
+from src.constants import FIELDMAPS_BASE_URL, PROJECT_PREFIX, STAGE
 from src.utils import blob
-
-FIELDMAPS_BASE_URL = "https://data.fieldmaps.io/cod/originals/{iso3}.shp.zip"
 
 
 def get_blob_name(iso3: str):
     iso3 = iso3.lower()
-    return f"{blob.PROJECT_PREFIX}/raw/codab/{iso3}.shp.zip"
+    return f"{PROJECT_PREFIX}/raw/codab/{iso3}.shp.zip"
 
 
 def download_codab_to_blob(iso3: str, clobber: bool = False):
     iso3 = iso3.lower()
     blob_name = get_blob_name(iso3)
-    if not clobber and blob_name in blob.list_container_blobs(
-        name_starts_with=f"{blob.PROJECT_PREFIX}/raw/codab/", stage=STAGE
+    if not clobber and blob_name in ocha.list_container_blobs(
+        name_starts_with=f"{PROJECT_PREFIX}/raw/codab/", stage=STAGE
     ):
         print(f"{blob_name} already exists in blob storage")
         return
     url = FIELDMAPS_BASE_URL.format(iso3=iso3)
     response = requests.get(url)
     response.raise_for_status()
-    blob.upload_blob_data(blob_name, response.content, stage=STAGE)
+
+    # Should eventually get this from ocha-stratus
+    blob._upload_blob_data(blob_name, response.content, stage=STAGE)
 
 
 def load_codab_from_blob(iso3: str, admin_level: int = 0):
     iso3 = iso3.lower()
     shapefile = f"{iso3}_adm{admin_level}.shp"
-    gdf = blob.load_gdf_from_blob(
+    gdf = ocha.load_shp_from_blob(
         blob_name=get_blob_name(iso3), shapefile=shapefile, stage=STAGE
     )
     return gdf

--- a/src/datasources/codab.py
+++ b/src/datasources/codab.py
@@ -1,4 +1,4 @@
-import ocha_stratus as ocha
+import ocha_stratus as stratus
 import requests
 
 from src.constants import FIELDMAPS_BASE_URL, PROJECT_PREFIX, STAGE
@@ -13,7 +13,7 @@ def get_blob_name(iso3: str):
 def download_codab_to_blob(iso3: str, clobber: bool = False):
     iso3 = iso3.lower()
     blob_name = get_blob_name(iso3)
-    if not clobber and blob_name in ocha.list_container_blobs(
+    if not clobber and blob_name in stratus.list_container_blobs(
         name_starts_with=f"{PROJECT_PREFIX}/raw/codab/", stage=STAGE
     ):
         print(f"{blob_name} already exists in blob storage")
@@ -29,7 +29,7 @@ def download_codab_to_blob(iso3: str, clobber: bool = False):
 def load_codab_from_blob(iso3: str, admin_level: int = 0):
     iso3 = iso3.lower()
     shapefile = f"{iso3}_adm{admin_level}.shp"
-    gdf = ocha.load_shp_from_blob(
+    gdf = stratus.load_shp_from_blob(
         blob_name=get_blob_name(iso3), shapefile=shapefile, stage=STAGE
     )
     return gdf

--- a/src/datasources/floodscan.py
+++ b/src/datasources/floodscan.py
@@ -269,7 +269,7 @@ def calculate_flood_exposure_rasterstats(
                 if_exists="append",
                 chunksize=10000,
                 index=False,
-                method=database.postgres_upsert,
+                method=ocha.postgres_upsert,
             )
 
 
@@ -296,7 +296,7 @@ def calculate_flood_exposure_rasterstats_regions(
         if_exists="append",
         chunksize=10000,
         index=False,
-        method=database.postgres_upsert,
+        method=ocha.postgres_upsert,
     )
 
 

--- a/src/datasources/floodscan.py
+++ b/src/datasources/floodscan.py
@@ -1,14 +1,15 @@
 from datetime import datetime
 from typing import Literal
 
+import ocha_stratus as ocha
 import pandas as pd
 import xarray as xr
 from sqlalchemy.engine import Engine
 from tqdm.auto import tqdm
 
-from src.constants import STAGE
+from src.constants import FLOODSCAN_COG_FILEPATH, PROJECT_PREFIX, STAGE
 from src.datasources import codab, worldpop
-from src.utils import blob, database
+from src.utils import database
 
 
 def calculate_flood_exposure_rasters(
@@ -38,8 +39,8 @@ def calculate_flood_exposure_rasters(
     # check for existing raw Floodscan rasters
     existing_fs_raw_files = [
         x
-        for x in blob.list_container_blobs(
-            name_starts_with=blob.FLOODSCAN_COG_FILEPATH,
+        for x in ocha.list_container_blobs(
+            name_starts_with=FLOODSCAN_COG_FILEPATH,
             container_name="raster",
             stage=STAGE,
         )
@@ -57,8 +58,8 @@ def calculate_flood_exposure_rasters(
         fs_raw_files = existing_fs_raw_files
 
     # check for existing processed exposure rasters
-    existing_exposure_files = blob.list_container_blobs(
-        name_starts_with=f"{blob.PROJECT_PREFIX}/processed/flood_exposure/"
+    existing_exposure_files = ocha.list_container_blobs(
+        name_starts_with=f"{PROJECT_PREFIX}/processed/flood_exposure/"
         f"{iso3}",
         stage=STAGE,
     )
@@ -77,7 +78,7 @@ def calculate_flood_exposure_rasters(
             if verbose:
                 print(f"already processed for {date_str}, skipping")
             continue
-        da_in = blob.open_blob_cog(
+        da_in = ocha.open_blob_cog(
             blob_name, container_name="raster", stage=STAGE
         )
         long_name = da_in.attrs["long_name"]
@@ -105,8 +106,8 @@ def calculate_flood_exposure_rasters(
     # interpolate to Worldpop grid and
     # multiply by population to get exposure
     exposure = ds_recent_filtered.interp_like(pop, method="nearest") * pop
-    existing_exposure_files = blob.list_container_blobs(
-        name_starts_with=f"{blob.PROJECT_PREFIX}/processed/flood_exposure/"
+    existing_exposure_files = ocha.list_container_blobs(
+        name_starts_with=f"{PROJECT_PREFIX}/processed/flood_exposure/"
         f"{iso3}",
         stage=STAGE,
     )
@@ -121,7 +122,7 @@ def calculate_flood_exposure_rasters(
             continue
         if verbose:
             print(f"uploading {blob_name}")
-        blob.upload_cog_to_blob(
+        ocha.upload_cog_to_blob(
             blob_name, exposure.sel(date=date), stage=STAGE
         )
 
@@ -162,8 +163,8 @@ def calculate_flood_exposure_rasterstats(
     adm = codab.load_codab_from_blob(iso3, admin_level=2)
     existing_exposure_rasters = [
         x
-        for x in blob.list_container_blobs(
-            name_starts_with=f"{blob.PROJECT_PREFIX}/processed/"
+        for x in ocha.list_container_blobs(
+            name_starts_with=f"{PROJECT_PREFIX}/processed/"
             f"flood_exposure/{iso3}/",
             stage=STAGE,
         )
@@ -195,7 +196,7 @@ def calculate_flood_exposure_rasterstats(
                 blob_name.split("/")[-1][13:23], "%Y-%m-%d"
             )
             try:
-                da_in = blob.open_blob_cog(blob_name, stage=STAGE)
+                da_in = ocha.open_blob_cog(blob_name, stage=STAGE)
                 da_in["date"] = date_in
                 da_in = da_in.persist()
                 das.append(da_in)
@@ -326,16 +327,16 @@ def get_blob_name(
         if date is None:
             raise ValueError("date must be provided for exposure data")
         return (
-            f"{blob.PROJECT_PREFIX}/processed/flood_exposure/"
+            f"{PROJECT_PREFIX}/processed/flood_exposure/"
             f"{iso3}/{iso3}_exposure_{date}.tif"
         )
     elif data_type == "exposure_tabular":
         return (
-            f"{blob.PROJECT_PREFIX}/processed/flood_exposure/tabular/"
+            f"{PROJECT_PREFIX}/processed/flood_exposure/tabular/"
             f"{iso3}_adm_flood_exposure.parquet"
         )
     elif data_type == "flood_extent":
         return (
-            f"{blob.PROJECT_PREFIX}/processed/flood_extent/"
+            f"{PROJECT_PREFIX}/processed/flood_extent/"
             f"{iso3}_flood_extent.tif"
         )

--- a/src/datasources/worldpop.py
+++ b/src/datasources/worldpop.py
@@ -1,23 +1,18 @@
 from io import BytesIO
 
 import numpy as np
+import ocha_stratus as ocha
 import requests
 import rioxarray as rxr
 
-from src.constants import STAGE
+from src.constants import PROJECT_PREFIX, STAGE, WORLDPOP_BASE_URL
 from src.utils import blob
-
-WORLDPOP_BASE_URL = (
-    "https://data.worldpop.org/GIS/Population/"
-    "Global_2000_2020_1km_UNadj/2020/{iso3_upper}/"
-    "{iso3}_ppp_2020_1km_Aggregated_UNadj.tif"
-)
 
 
 def get_blob_name(iso3: str):
     iso3 = iso3.lower()
     return (
-        f"{blob.PROJECT_PREFIX}/raw/worldpop/"
+        f"{PROJECT_PREFIX}/raw/worldpop/"
         f"{iso3}_ppp_2020_1km_Aggregated_UNadj.tif"
     )
 
@@ -25,8 +20,8 @@ def get_blob_name(iso3: str):
 def download_worldpop_to_blob(iso3: str, clobber: bool = False):
     iso3 = iso3.lower()
     blob_name = get_blob_name(iso3)
-    if not clobber and blob_name in blob.list_container_blobs(
-        name_starts_with=f"{blob.PROJECT_PREFIX}/raw/worldpop/", stage=STAGE
+    if not clobber and blob_name in ocha.list_container_blobs(
+        name_starts_with=f"{PROJECT_PREFIX}/raw/worldpop/", stage=STAGE
     ):
         print(f"{blob_name} already exists in blob storage")
         return

--- a/src/datasources/worldpop.py
+++ b/src/datasources/worldpop.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 
 import numpy as np
-import ocha_stratus as ocha
+import ocha_stratus as stratus
 import requests
 import rioxarray as rxr
 
@@ -20,7 +20,7 @@ def get_blob_name(iso3: str):
 def download_worldpop_to_blob(iso3: str, clobber: bool = False):
     iso3 = iso3.lower()
     blob_name = get_blob_name(iso3)
-    if not clobber and blob_name in ocha.list_container_blobs(
+    if not clobber and blob_name in stratus.list_container_blobs(
         name_starts_with=f"{PROJECT_PREFIX}/raw/worldpop/", stage=STAGE
     ):
         print(f"{blob_name} already exists in blob storage")

--- a/src/utils/blob.py
+++ b/src/utils/blob.py
@@ -1,128 +1,7 @@
-import io
-import os
-import shutil
-import tempfile
-import zipfile
 from typing import Literal
 
-import geopandas as gpd
-import pandas as pd
-import rioxarray as rxr
-import xarray as xr
-from azure.storage.blob import ContainerClient, ContentSettings
-from dotenv import load_dotenv
-
-load_dotenv()
-
-DSCI_AZ_BLOB_PROD_SAS_WRITE = os.getenv("DSCI_AZ_BLOB_PROD_SAS_WRITE")
-DSCI_AZ_BLOB_DEV_SAS_WRITE = os.getenv("DSCI_AZ_BLOB_DEV_SAS_WRITE")
-
-PROJECT_PREFIX = "ds-floodexposure-monitoring"
-FLOODSCAN_COG_FILEPATH = "floodscan/daily/v5/processed"
-
-
-def get_container_client(
-    container_name: str = "projects", stage: Literal["prod", "dev"] = "dev"
-):
-    sas = (
-        DSCI_AZ_BLOB_DEV_SAS_WRITE
-        if stage == "dev"
-        else DSCI_AZ_BLOB_PROD_SAS_WRITE
-    )
-    container_url = (
-        f"https://imb0chd0{stage}.blob.core.windows.net/"
-        f"{container_name}?{sas}"
-    )
-    return ContainerClient.from_container_url(container_url)
-
-
-def upload_parquet_to_blob(
-    blob_name,
-    df,
-    stage: Literal["prod", "dev"] = "dev",
-    container_name: str = "projects",
-    **kwargs,
-):
-    upload_blob_data(
-        blob_name,
-        df.to_parquet(**kwargs),
-        stage=stage,
-        container_name=container_name,
-    )
-
-
-def load_parquet_from_blob(
-    blob_name,
-    stage: Literal["prod", "dev"] = "dev",
-    container_name: str = "projects",
-):
-    blob_data = load_blob_data(
-        blob_name, stage=stage, container_name=container_name
-    )
-    return pd.read_parquet(io.BytesIO(blob_data))
-
-
-def upload_csv_to_blob(
-    blob_name,
-    df,
-    stage: Literal["prod", "dev"] = "dev",
-    container_name: str = "projects",
-    **kwargs,
-):
-    upload_blob_data(
-        blob_name,
-        df.to_csv(index=False, **kwargs),
-        stage=stage,
-        content_type="text/csv",
-        container_name=container_name,
-    )
-
-
-def load_csv_from_blob(
-    blob_name,
-    stage: Literal["prod", "dev"] = "dev",
-    container_name: str = "projects",
-    **kwargs,
-):
-    blob_data = load_blob_data(
-        blob_name, stage=stage, container_name=container_name
-    )
-    return pd.read_csv(io.BytesIO(blob_data), **kwargs)
-
-
-def upload_gdf_to_blob(gdf, blob_name, stage: Literal["prod", "dev"] = "dev"):
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # File paths for shapefile components within the temp directory
-        shp_base_path = os.path.join(temp_dir, "data")
-
-        gdf.to_file(shp_base_path, driver="ESRI Shapefile")
-
-        zip_file_path = os.path.join(temp_dir, "data")
-
-        shutil.make_archive(
-            base_name=zip_file_path, format="zip", root_dir=temp_dir
-        )
-
-        # Define the full path to the zip file
-        full_zip_path = f"{zip_file_path}.zip"
-
-        # Upload the buffer content as a blob
-        with open(full_zip_path, "rb") as data:
-            upload_blob_data(blob_name, data, stage=stage)
-
-
-def load_gdf_from_blob(
-    blob_name, shapefile: str = None, stage: Literal["prod", "dev"] = "dev"
-):
-    blob_data = load_blob_data(blob_name, stage=stage)
-    with zipfile.ZipFile(io.BytesIO(blob_data), "r") as zip_ref:
-        zip_ref.extractall("temp")
-        if shapefile is None:
-            shapefile = [f for f in zip_ref.namelist() if f.endswith(".shp")][
-                0
-            ]
-        gdf = gpd.read_file(f"temp/{shapefile}")
-    return gdf
+import ocha_stratus as ocha
+from azure.storage.blob import ContentSettings
 
 
 def load_blob_data(
@@ -130,7 +9,7 @@ def load_blob_data(
     stage: Literal["prod", "dev"] = "dev",
     container_name: str = "projects",
 ):
-    container_client = get_container_client(
+    container_client = ocha.get_container_client(
         stage=stage, container_name=container_name
     )
     blob_client = container_client.get_blob_client(blob_name)
@@ -145,7 +24,7 @@ def upload_blob_data(
     container_name: str = "projects",
     content_type: str = None,
 ):
-    container_client = get_container_client(
+    container_client = ocha.get_container_client(
         stage=stage, container_name=container_name
     )
 
@@ -160,60 +39,3 @@ def upload_blob_data(
     blob_client.upload_blob(
         data, overwrite=True, content_settings=content_settings
     )
-
-
-def list_container_blobs(
-    name_starts_with=None,
-    stage: Literal["prod", "dev"] = "dev",
-    container_name: str = "projects",
-):
-    container_client = get_container_client(
-        stage=stage, container_name=container_name
-    )
-    return [
-        blob.name
-        for blob in container_client.list_blobs(
-            name_starts_with=name_starts_with
-        )
-    ]
-
-
-def get_blob_url(
-    blob_name,
-    stage: Literal["prod", "dev"] = "dev",
-    container_name: str = "projects",
-):
-    container_client = get_container_client(
-        stage=stage, container_name=container_name
-    )
-    blob_client = container_client.get_blob_client(blob_name)
-    return blob_client.url
-
-
-def open_blob_cog(
-    blob_name,
-    stage: Literal["prod", "dev"] = "dev",
-    container_name: str = "projects",
-    chunks=None,
-):
-    cog_url = get_blob_url(
-        blob_name, stage=stage, container_name=container_name
-    )
-    if chunks is None:
-        chunks = True
-    return rxr.open_rasterio(cog_url, chunks=chunks)
-
-
-def upload_cog_to_blob(
-    blob_name: str,
-    da: xr.DataArray,
-    stage: Literal["prod", "dev"] = "dev",
-    container_name: str = "projects",
-):
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".tif") as tmpfile:
-        temp_filename = tmpfile.name
-        da.rio.to_raster(temp_filename, driver="COG")
-        with open(temp_filename, "rb") as f:
-            get_container_client(
-                container_name=container_name, stage=stage
-            ).get_blob_client(blob_name).upload_blob(f, overwrite=True)

--- a/src/utils/blob.py
+++ b/src/utils/blob.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-import ocha_stratus as ocha
+import ocha_stratus as stratus
 from azure.storage.blob import ContentSettings
 
 
@@ -9,7 +9,7 @@ def load_blob_data(
     stage: Literal["prod", "dev"] = "dev",
     container_name: str = "projects",
 ):
-    container_client = ocha.get_container_client(
+    container_client = stratus.get_container_client(
         stage=stage, container_name=container_name
     )
     blob_client = container_client.get_blob_client(blob_name)
@@ -24,7 +24,7 @@ def upload_blob_data(
     container_name: str = "projects",
     content_type: str = None,
 ):
-    container_client = ocha.get_container_client(
+    container_client = stratus.get_container_client(
         stage=stage, container_name=container_name
     )
 

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -29,9 +29,10 @@ AZURE_DB_BASE_URL = "postgresql+psycopg2://{uid}:{pw}@{db_name}.postgres.databas
 
 def get_engine(stage: Literal["dev", "prod"]):
     if stage == "dev":
+        print("here!")
         url = AZURE_DB_BASE_URL.format(
-            uid=DSCI_AZ_DB_DEV_UID_WRITE,
-            pw=DSCI_AZ_DB_DEV_PW_WRITE,
+            uid="hannah",
+            pw="mF0hI5iLo7zH",
             db_name="chd-rasterstats-dev",
         )
     elif stage == "prod":

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -1,8 +1,6 @@
-import os
-from typing import List, Literal
+from typing import List
 
 import pandas as pd
-from dotenv import load_dotenv
 from sqlalchemy import (
     CHAR,
     REAL,
@@ -13,37 +11,7 @@ from sqlalchemy import (
     String,
     Table,
     UniqueConstraint,
-    create_engine,
 )
-from sqlalchemy.dialects.postgresql import insert
-
-load_dotenv()
-
-DSCI_AZ_DB_DEV_PW_WRITE = os.getenv("DSCI_AZ_DB_DEV_PW_WRITE")
-DSCI_AZ_DB_PROD_PW_WRITE = os.getenv("DSCI_AZ_DB_PROD_PW_WRITE")
-DSCI_AZ_DB_DEV_UID_WRITE = os.getenv("DSCI_AZ_DB_DEV_UID_WRITE")
-DSCI_AZ_DB_PROD_UID_WRITE = os.getenv("DSCI_AZ_DB_PROD_UID_WRITE")
-
-AZURE_DB_BASE_URL = "postgresql+psycopg2://{uid}:{pw}@{db_name}.postgres.database.azure.com/postgres"  # noqa: E501
-
-
-def get_engine(stage: Literal["dev", "prod"]):
-    if stage == "dev":
-        print("here!")
-        url = AZURE_DB_BASE_URL.format(
-            uid="hannah",
-            pw="mF0hI5iLo7zH",
-            db_name="chd-rasterstats-dev",
-        )
-    elif stage == "prod":
-        url = AZURE_DB_BASE_URL.format(
-            uid=DSCI_AZ_DB_PROD_UID_WRITE,
-            pw=DSCI_AZ_DB_PROD_PW_WRITE,
-            db_name="chd-rasterstats-prod",
-        )
-    else:
-        raise ValueError(f"Invalid stage: {stage}")
-    return create_engine(url)
 
 
 def create_flood_exposure_table(dataset, engine):
@@ -86,41 +54,6 @@ def create_flood_exposure_table(dataset, engine):
     )
 
     metadata.create_all(engine)
-    return
-
-
-def postgres_upsert(table, conn, keys, data_iter, constraint=None):
-    """
-    Perform an upsert (insert or update) operation on a PostgreSQL table. Adapted from:
-    https://stackoverflow.com/questions/55187884/insert-into-postgresql-table-from-pandas-with-on-conflict-update # noqa: E501
-
-    Parameters
-    ----------
-    table : sqlalchemy.sql.schema.Table
-        The SQLAlchemy Table object where the data will be inserted or updated.
-    conn : sqlalchemy.engine.Connection
-        The SQLAlchemy connection object used to execute the upsert operation.
-    keys : list of str
-        The list of column names used as keys for the upsert operation.
-    data_iter : iterable
-        An iterable of tuples or lists containing the data to be inserted or
-        updated.
-    constraint_name : str
-        Name of the uniqueness constraint
-
-    Returns
-    -------
-    None
-    """
-    if not constraint:
-        constraint = f"{table.table.name}_unique"
-    data = [dict(zip(keys, row)) for row in data_iter]
-    insert_statement = insert(table.table).values(data)
-    upsert_statement = insert_statement.on_conflict_do_update(
-        constraint=constraint,
-        set_={c.key: c for c in insert_statement.excluded},
-    )
-    conn.execute(upsert_statement)
     return
 
 


### PR DESCRIPTION
Deleting as much as possible from `blob.py` and `database.py`, to use functions from `ocha-stratus` instead. There's a good amount in the notebooks that I've left as is. Since these are all "exploratory", I don't think it's critical that they're maintained. I've also centralized global variables under `constants.py`, as I started moving things over from `blob.py` (since I'd like to delete this whole file eventually) and wanted to keep everything consistent. 

This is also demonstrating that I'll need to update `_load_blob_data` and `_upload_blob_data` to be external functions in the `ocha-stratus` package. 

And what do you think of using it as: `import ocha_stratus as ocha`? I think shortening is important, and we certainly can't use `os`. 