### PR TITLE
Improve memory consumption

### DIFF
--- a/src/datasources/floodscan.py
+++ b/src/datasources/floodscan.py
@@ -68,8 +68,7 @@ def calculate_flood_exposure_rasters(
 
     # Split files into batches of size batch_size
     total_files = len(fs_raw_files)
-    if verbose:
-        print(f"Total files to process: {total_files}")
+    print(f"Total files to process: {total_files}")
 
     for batch_start in range(0, total_files, batch_size):
         batch_end = min(batch_start + batch_size, total_files)

--- a/src/datasources/floodscan.py
+++ b/src/datasources/floodscan.py
@@ -134,7 +134,7 @@ def process_batch_flood_exposure(
     exposure = ds_recent_filtered.interp_like(pop, method="nearest") * pop
 
     # iterate over dates and upload COGs to blob storage
-    for date in tqdm(exposure.date):
+    for date in exposure.date:
         date_str = str(date.values.astype("datetime64[D]"))
         blob_name = get_blob_name(iso3, "exposure_raster", date=date_str)
         if blob_name in existing_exposure_files and not clobber:

--- a/src/datasources/floodscan.py
+++ b/src/datasources/floodscan.py
@@ -212,7 +212,7 @@ def calculate_flood_exposure_rasterstats(
     for exposure_raster_chunk in tqdm(exposure_raster_chunks):
         # stack up exposure rasters in chunk
         das = []
-        for blob_name in tqdm(exposure_raster_chunk):
+        for blob_name in exposure_raster_chunk:
             date_in = datetime.strptime(
                 blob_name.split("/")[-1][13:23], "%Y-%m-%d"
             )
@@ -236,9 +236,7 @@ def calculate_flood_exposure_rasterstats(
 
         # iterate over admin level 2 regions and calculate exposure sums
         dfs = []
-        for pcode, row in tqdm(
-            adm.set_index("ADM2_PCODE").iterrows(), total=len(adm)
-        ):
+        for pcode, row in adm.set_index("ADM2_PCODE").iterrows():
             da_clip = ds_exp_recent.rio.clip([row.geometry])
             dff = (
                 da_clip.sum(dim=["x", "y"])

--- a/src/datasources/floodscan.py
+++ b/src/datasources/floodscan.py
@@ -70,7 +70,7 @@ def calculate_flood_exposure_rasters(
     total_files = len(fs_raw_files)
     print(f"Total files to process: {total_files}")
 
-    for batch_start in range(0, total_files, batch_size):
+    for batch_start in tqdm(range(0, total_files, batch_size)):
         batch_end = min(batch_start + batch_size, total_files)
         current_batch = fs_raw_files[batch_start:batch_end]
 
@@ -92,7 +92,7 @@ def process_batch_flood_exposure(
     """Process a batch of files"""
     # stack up relevant raw Floodscan rasters for this batch
     das = []
-    for blob_name in tqdm(file_batch):
+    for blob_name in file_batch:
         date_in = datetime.strptime(
             blob_name.split("/")[-1][15:25], "%Y-%m-%d"
         )


### PR DESCRIPTION
This COG stacking keeps crashing the GHA runner or the Databricks cluster. Splitting the COG stacking into batches of 100 -- similar to how we've done for the raster stats computation. Unfortunately I'm not sure why this doesn't seem to be an issue when we run the pipelines locally... But regardless I don't think it's a bad idea to split this up.

I've also removed some of the lower level progress indicators (`tqdm`). More of a personal thing, but I'm finding when it really matters in the long updates, updating on each file per chunk makes the logs too busy to actually see anything. 